### PR TITLE
INFRA-869: Add CODEOWNERS and MAINTAINERS.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @intenthq/legacy-maintenance

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,9 @@
+# Maintainers
+
+This repository is maintained by the **Legacy Maintenance** team.
+
+## Team
+
+- **GitHub**: [@intenthq/legacy-maintenance](https://github.com/orgs/intenthq/teams/legacy-maintenance)
+- **Slack channel**: `#team-foundation`
+- **Slack group**: `@legacy-maintenance`


### PR DESCRIPTION
## Summary

- Add `CODEOWNERS` file assigning `@intenthq/legacy-maintenance` as default code owners
- Add `MAINTAINERS.md` documenting the Legacy Maintenance team as repository maintainers

Tracked by INFRA-869

🤖 Generated with [Claude Code](https://claude.com/claude-code)