### PR TITLE
INFRA-1344: Replace MIT licence with proprietary licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,22 @@
-The MIT License (MIT)
+Copyright (c) 2026 Intent HQ Limited. All rights reserved.
 
-Copyright (c) 2020 Intent HQ
+This software, including the source code in this repository and any
+binary artifacts published from it (including, without limitation,
+artifacts published to Maven Central), is the proprietary and
+confidential property of Intent HQ Limited ("Intent HQ").
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+NO LICENCE IS GRANTED BY THIS REPOSITORY OR BY ANY PUBLISHED ARTIFACT.
+Use, copying, modification, distribution, or incorporation of this
+software, in whole or in part, is permitted only under the terms of a
+separate written commercial agreement with Intent HQ. Without such an
+agreement, no rights of any kind are granted, whether by implication,
+estoppel, or otherwise.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT.
+IN NO EVENT SHALL INTENT HQ BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER
+LIABILITY ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR
+THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+For licensing enquiries, contact: legal@intenthq.com

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # Action Processor Integrations
 
 ![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/intenthq/action-processor-integrations?color=blue&include_prereleases&label=release) [![CI Status](https://github.com/intenthq/action-processor-integrations/workflows/CI/badge.svg)](https://github.com/intenthq/action-processor-integrations/actions?query=workflow%3ACI)
+
+A library of interfaces that clients of Intent HQ's Action Processor
+build their custom data integrations against (CSV / SFTP / S3 feeds).
+
+## Licence and use
+
+This repository hosts proprietary software belonging to Intent HQ Limited.
+It is public solely because the library is distributed via Maven Central
+so that clients can consume it to build their own integrations against
+the Action Processor.
+
+Use of this software — including any artifact published to Maven Central
+from this repository — requires a commercial agreement with Intent HQ
+Limited. See [LICENSE](LICENSE).
+
+For licensing enquiries: legal@intenthq.com

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,9 @@ ThisBuild / organizationHomepage := Some(url("https://www.intenthq.com/"))
 
 ThisBuild / homepage := Some(url("https://github.com/intenthq/action-processor-integrations"))
 ThisBuild / developers := List(Developer("intenthq", "Intent HQ", null, url("https://www.intenthq.com/")))
-ThisBuild / licenses := Seq(("MIT", url("http://opensource.org/licenses/MIT")))
+ThisBuild / licenses := Seq(
+  ("Proprietary", url("https://github.com/intenthq/action-processor-integrations/blob/master/LICENSE"))
+)
 
 ThisBuild / scalaVersion := "2.13.10"
 ThisBuild / semanticdbEnabled := true


### PR DESCRIPTION
## Summary

- Replaces the MIT `LICENSE` with a restrictive "all rights reserved / commercial agreement required" notice that explicitly covers artifacts published to Maven Central.
- Updates the `build.sbt` POM licence metadata from MIT to Proprietary so artifacts published to Maven Central carry the correct licence pointer.
- Adds a Licence and use section to the README describing why the repo is public and pointing at the LICENSE.

## Context

Linear: [INFRA-1344](https://linear.app/intent-hq/issue/INFRA-1344/add-restrictive-license-readme-to-commercial-distribution-public-repos)

Colin White is finalising a Disclosure notice for our public GitHub repos and has classified them into:

1. **Open source** — community OSS, stays public under an OSS licence.
2. **Commercial distribution** — must stay public because the distribution mechanism requires it (SPM, CocoaPods, Maven Central); should carry a restrictive licence + a README notice that use requires a commercial agreement with Intent HQ.
3. **Internal / proprietary** — should be moved private.

This library belongs in Cat 2: it is published to Maven Central so that clients (notably VZW, per Alekhya Deba — confirmed still in use as of last month) can build their own integrations against the Action Processor.

The current MIT licence is the wrong posture for that — MIT actively grants third parties the right to use, modify, and redistribute. We want use to be conditional on a commercial agreement.

Slack confirmation that the repo must stay public for Maven distribution: [thread](https://intent.slack.com/archives/C12JTN7P1/p1776861368351479) (Fernando Mora, Alekhya Deba).

## Outstanding confirmation

The LICENSE points licensing enquiries at \`legal@intenthq.com\`. Will confirm with Colin that this is the right destination before this lands.

## Test plan

- [ ] Confirm \`legal@intenthq.com\` is the correct contact address with Colin / Ryan.
- [ ] Confirm the licence wording is acceptable to legal.
- [ ] Confirm with Fernando / Albert / Alekhya that swapping from MIT to a proprietary licence does not impact existing client integrations.