### PR TITLE
fix: resolve zizmor excessive-permissions + artipacked (INFRA-869)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,15 @@ on:
     branches:
       - master
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           java-version: 11

--- a/.github/workflows/release-sonatype.yml
+++ b/.github/workflows/release-sonatype.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   release-sonatype:
     runs-on: ubuntu-latest
@@ -14,6 +17,7 @@ jobs:
         with:
           # We need to unshallow to allow git describe work with last tag
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-java@v4
         with:
           java-version: 11


### PR DESCRIPTION
## What

Thin mechanical pass for `action-processor-integrations`: least-privilege permissions: contents: read on ci + release-sonatype (Sonatype publishing uses PGP/Sonatype creds, not GITHUB_TOKEN); persist-credentials: false on checkouts (no git pushes).

**Deliberately deferred** (INFRA-869 cross-cutting decision pending): `unpinned-uses` — the bulk of this repo's findings — awaiting the org pin-vs-SHA vs wrap-in-github-actions call.

Verified with org config `zizmor --config zizmor.yml`: 0 findings outside the deferred set.

INFRA-869

🤖 Generated with [Claude Code](https://claude.com/claude-code)