### PR TITLE
ci: bump Java 11 -> 17 and add build timeout (INFRA-923)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: "temurin"
       - uses: coursier/cache-action@v8
       - name: Setup sbt launcher

--- a/.github/workflows/release-sonatype.yml
+++ b/.github/workflows/release-sonatype.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: "temurin"
       - uses: coursier/cache-action@v8
       - id: test


### PR DESCRIPTION
## Summary

CI `build` jobs on recent PRs (#40, #41) ran for the full **360-minute default timeout** and were cancelled.

**Root cause:** `sbt test` loads `eclipse-collections` (pulled in transitively via `mapdb`), which is compiled for **Java 17 (class file v61.0)**. On the workflow's pinned **Java 11** runtime this throws `UnsupportedClassVersionError`. The error surfaces on a cats-effect `io-compute-blocker` thread and never propagates to the sbt test runner, so the suite **hangs indefinitely** until GitHub kills it at 6h. It is unrelated to what #40/#41 changed — a latent dependency/runtime mismatch any PR now hits.

## Changes
- `ci.yml` & `release-sonatype.yml`: `java-version` **11 → 17**
- `ci.yml`: add `timeout-minutes: 30` to the build job so a future hang fails fast instead of burning 6h of runner time

## Verification
Ran `sbt test` locally on Java 17 (Corretto 17.0.4) — all green:
```
[info] Passed: Total 14, Failed 0, Errors 0, Passed 14
[success] Total time: 22 s
```
No `UnsupportedClassVersionError`; mapdb/eclipse-collections (heavy reflection/Unsafe users) load fine.

Tracked under INFRA-923.

🤖 Generated with [Claude Code](https://claude.com/claude-code)